### PR TITLE
Change dialects to be classes rather than modules

### DIFF
--- a/src/stringifiers/dialects/mixins/pagination-not-supported.js
+++ b/src/stringifiers/dialects/mixins/pagination-not-supported.js
@@ -2,10 +2,23 @@ function throwErr() {
   throw new Error('This type of pagination not supported on this dialect')
 }
 
+const PaginationNotSupported = (superclass) => class extends superclass {
+  // eslint-disable-next-line class-methods-use-this
+  handlePaginationAtRoot() { throwErr() }
+
+  // eslint-disable-next-line class-methods-use-this
+  handleJoinedOneToManyPaginated() { throwErr() }
+
+  // eslint-disable-next-line class-methods-use-this
+  handleBatchedOneToManyPaginated() { throwErr() }
+
+  // eslint-disable-next-line class-methods-use-this
+  handleJoinedManyToManyPaginated() { throwErr() }
+
+  // eslint-disable-next-line class-methods-use-this
+  handleBatchedManyToManyPaginated() { throwErr() }
+}
+
 module.exports = {
-  handlePaginationAtRoot: throwErr,
-  handleJoinedOneToManyPaginated: throwErr,
-  handleBatchedOneToManyPaginated: throwErr,
-  handleJoinedManyToManyPaginated: throwErr,
-  handleBatchedManyToManyPaginated: throwErr
+  PaginationNotSupported
 }

--- a/src/stringifiers/dialects/mysql.js
+++ b/src/stringifiers/dialects/mysql.js
@@ -1,16 +1,23 @@
-function quote(str) {
-  return `\`${str}\``
+import { PaginationNotSupported } from './mixins/pagination-not-supported'
+
+class Dialect extends PaginationNotSupported(function () { }) {
+  // eslint-disable-next-line class-methods-use-this
+  get name() {
+    return 'mysql'
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  quote(str) {
+    return `\`${str}\``
+  }
+
+  compositeKey(parent, keys) {
+    keys = keys.map(key => `${this.quote(parent)}.${this.quote(key)}`)
+    return `CONCAT(${keys.join(', ')})`
+  }
 }
 
 module.exports = {
-  ...require('./mixins/pagination-not-supported'),
-
-  name: 'mysql',
-
-  quote,
-
-  compositeKey(parent, keys) {
-    keys = keys.map(key => `${quote(parent)}.${quote(key)}`)
-    return `CONCAT(${keys.join(', ')})`
-  }
+  dialect: new Dialect(),
+  Dialect,
 }

--- a/src/stringifiers/dialects/mysql8.js
+++ b/src/stringifiers/dialects/mysql8.js
@@ -1,16 +1,13 @@
-function quote(str) {
-  return `\`${str}\``
+import { Dialect as MariaDB } from './mariadb'
+
+class Dialect extends MariaDB {
+  // eslint-disable-next-line class-methods-use-this
+  get name() {
+    return 'mysql8'
+  }
 }
 
 module.exports = {
-  ...require('./mariadb'),
-
-  name: 'mysql8',
-
-  quote,
-
-  compositeKey(parent, keys) {
-    keys = keys.map(key => `${quote(parent)}.${quote(key)}`)
-    return `CONCAT(${keys.join(', ')})`
-  }
+  dialect: new Dialect(),
+  Dialect,
 }

--- a/src/stringifiers/dialects/sqlite3.js
+++ b/src/stringifiers/dialects/sqlite3.js
@@ -1,16 +1,21 @@
-function quote(str) {
-  return `"${str}"`
+import { PaginationNotSupported } from './mixins/pagination-not-supported'
+
+class Dialect extends PaginationNotSupported(function () { }) {
+  // eslint-disable-next-line class-methods-use-this
+  get name() { return 'sqlite3' }
+
+  // eslint-disable-next-line class-methods-use-this
+  quote(str) {
+    return `"${str}"`
+  }
+
+  compositeKey(parent, keys) {
+    keys = keys.map(key => `${this.quote(parent)}.${this.quote(key)}`)
+    return keys.join(' || ')
+  }
 }
 
 module.exports = {
-  ...require('./mixins/pagination-not-supported'),
-
-  name: 'sqlite3',
-
-  quote,
-
-  compositeKey(parent, keys) {
-    keys = keys.map(key => `${quote(parent)}.${quote(key)}`)
-    return keys.join(' || ')
-  }
+  dialect: new Dialect(),
+  Dialect,
 }

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -16,13 +16,21 @@ export default async function stringifySqlAST(topNode, context, options) {
   let dialect = options.dialectModule
 
   if (!dialect && options.dialect) {
+
+    let { dialect: sqlite3 } = require('./dialects/sqlite3')
+    let { dialect: pg } = require('./dialects/pg')
+    let { dialect: oracle } = require('./dialects/oracle')
+    let { dialect: mysql8 } = require('./dialects/mysql8')
+    let { dialect: mysql } = require('./dialects/mysql')
+    let { dialect: mariadb } = require('./dialects/mariadb')
+
     const dialectRequireOptions = {
-      sqlite3: require('./dialects/sqlite3'),
-      pg: require('./dialects/pg'),
-      oracle: require('./dialects/oracle'),
-      mysql8: require('./dialects/mysql8'),
-      mysql: require('./dialects/mysql'),
-      mariadb: require('./dialects/mariadb'),
+      sqlite3,
+      pg,
+      oracle,
+      mysql8,
+      mysql,
+      mariadb,
     }
     dialect = dialectRequireOptions[options.dialect]
   }

--- a/test-api/schema-basic/QueryRoot.js
+++ b/test-api/schema-basic/QueryRoot.js
@@ -13,10 +13,10 @@ import User from './User'
 import Sponsor from './Sponsor'
 import { fromBase64, q } from '../shared'
 
-import mysqlModule from '../../src/stringifiers/dialects/mysql'
-import oracleModule from '../../src/stringifiers/dialects/oracle'
-import pgModule from '../../src/stringifiers/dialects/pg'
-import sqlite3Module from '../../src/stringifiers/dialects/sqlite3'
+import { dialect as mysqlModule } from '../../src/stringifiers/dialects/mysql'
+import { dialect as oracleModule } from '../../src/stringifiers/dialects/oracle'
+import { dialect as pgModule } from '../../src/stringifiers/dialects/pg'
+import { dialect as sqlite3Module } from '../../src/stringifiers/dialects/sqlite3'
 
 import joinMonster from '../../src/index'
 


### PR DESCRIPTION
### Description

This allows dialects to more easily be extended. Without classes, dialects were capturing helper functions. That made it hard to use those functions while providing alternate versions of the helpers. With classes, the binding gets deferred until the function is called.

