### PR TITLE
Add a new dialect property for unlimited LIMITs

### DIFF
--- a/src/stringifiers/README.md
+++ b/src/stringifiers/README.md
@@ -13,6 +13,7 @@ Each dialect must implement certain cases (functions) to plug into the dispatche
 1. handleJoinedManyToManyPaginated
 1. handleBatchedManyToManyPaginated
 1. handleBatchedOneToManyPaginated
+1. unlimitedLimit (optional)
 
 Implementing a new dialect should just mean creating a new object with those methods in a file inside `dialects`.
 

--- a/src/stringifiers/dialects/mariadb.js
+++ b/src/stringifiers/dialects/mariadb.js
@@ -7,8 +7,9 @@ import {
   orderingsToString
 } from '../shared'
 import { PaginationNotSupported } from './mixins/pagination-not-supported'
+import { UnlimitedLimitIsMaxint } from './mixins/unlimitedLimit-is-maxint'
 
-class Dialect extends PaginationNotSupported(function () { }) {
+class Dialect extends UnlimitedLimitIsMaxint(PaginationNotSupported(function () { })) {
   // eslint-disable-next-line class-methods-use-this
   get name() { return 'mariadb' }
 

--- a/src/stringifiers/dialects/mixins/unlimitedLimit-is-maxint.js
+++ b/src/stringifiers/dialects/mixins/unlimitedLimit-is-maxint.js
@@ -1,0 +1,11 @@
+const UnlimitedLimitIsMaxint = (superclass) => class extends superclass {
+  // eslint-disable-next-line class-methods-use-this
+  unlimitedLimit() {
+    return '18446744073709551615'
+  }
+}
+
+module.exports = {
+  UnlimitedLimitIsMaxint
+}
+

--- a/src/stringifiers/dialects/mysql.js
+++ b/src/stringifiers/dialects/mysql.js
@@ -1,6 +1,7 @@
 import { PaginationNotSupported } from './mixins/pagination-not-supported'
+import { UnlimitedLimitIsMaxint } from './mixins/unlimitedLimit-is-maxint'
 
-class Dialect extends PaginationNotSupported(function () { }) {
+class Dialect extends UnlimitedLimitIsMaxint(PaginationNotSupported(function () { })) {
   // eslint-disable-next-line class-methods-use-this
   get name() {
     return 'mysql'

--- a/src/stringifiers/dialects/oracle.js
+++ b/src/stringifiers/dialects/oracle.js
@@ -4,9 +4,10 @@ import {
   interpretForOffsetPaging,
   orderingsToString
 } from '../shared'
+import { UnlimitedLimitIsMaxint } from './mixins/unlimitedLimit-is-maxint'
 import { Dialect as PostgresDialect } from './pg'
 
-class Dialect extends PostgresDialect {
+class Dialect extends UnlimitedLimitIsMaxint(PostgresDialect) {
   // eslint-disable-next-line class-methods-use-this
   get name() { return 'oracle' }
 

--- a/src/stringifiers/shared.js
+++ b/src/stringifiers/shared.js
@@ -177,9 +177,7 @@ export function interpretForOffsetPaging(node, dialect) {
     order.columns = node.junction.orderBy
   }
 
-  let limit = ['mariadb', 'mysql', 'oracle'].includes(name)
-    ? '18446744073709551615'
-    : 'ALL'
+  let limit = dialect.unlimitedLimit ? dialect.unlimitedLimit() : 'ALL'
   if (idx(node, _ => _.defaultPageSize)) {
     limit = node.defaultPageSize + 1
   }


### PR DESCRIPTION
### Description

This previously was hardcoded based on dialect in a helper function, but this factors it out into the dialect. Snowflake uses an alternate syntax, so having it factored allows users to develop a Snowflake dialect.

