### PR TITLE
Fix CI to actually build

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install Node Deps
         run: npm ci
 
+      - name: Build the project
+        run: npm run build
+
       - name: "Publish if Changed"
         id: publish
         uses: JS-DevTools/npm-publish@v3


### PR DESCRIPTION
### Description

Upgrading to JS-DevTools/npm-publish@v3 caused the CI pipeline to not actually build the code. This commit fixes that.

